### PR TITLE
Adds sermon date to summary - closes #30

### DIFF
--- a/content/sermons/christ-fulfillment-of-promise-1973-0069.md
+++ b/content/sermons/christ-fulfillment-of-promise-1973-0069.md
@@ -5,7 +5,7 @@ categories: ["sermons"]
 tags: ["Christmas", "1973", "handwritten"]
 rcl_year: "B"
 rcl_season: "Christmas"
-sermon_date: 2073-12-30
+sermon_date: 1973-12-30
 sermon_scan: true
 sermon_text: false
 sermon_audio: false

--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -7,6 +7,7 @@
 
       <ul class="facts">
         <li><i class="far fa-calendar-plus" aria-hidden="true"></i><time datetime="{{ .Date.Format "2006-01-02T15:04:05JST" }}">{{ .Date.Format ( .Site.Params.dateformat | default "Jan 2, 2006") }}</time></li>
+        <li><i class="far fa-calendar-alt" aria-hidden="true"></i>{{.Params.sermon_date}}</li>
         {{ with .Section }}<li><i class="fas fa-bookmark" aria-hidden="true"></i>{{ . | upper }}</li>{{ end }}
         {{ if eq (getenv "HUGO_ENV") "DEV" }}
         <li>{{ .WordCount }} Words</li>

--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -1,0 +1,20 @@
+<article class="li">
+  <a href="{{ .Permalink }}">
+    <div class="thumb thumb-{{ .File.UniqueID }}"></div>
+
+    <div class="inner">
+      <h2 class="title">{{ .Title }}</h2>
+
+      <ul class="facts">
+        <li><i class="far fa-calendar-plus" aria-hidden="true"></i><time datetime="{{ .Date.Format "2006-01-02T15:04:05JST" }}">{{ .Date.Format ( .Site.Params.dateformat | default "Jan 2, 2006") }}</time></li>
+        {{ with .Section }}<li><i class="fas fa-bookmark" aria-hidden="true"></i>{{ . | upper }}</li>{{ end }}
+        {{ if eq (getenv "HUGO_ENV") "DEV" }}
+        <li>{{ .WordCount }} Words</li>
+        {{ if .IsDraft }}<li style="color: #2196f3;">DRAFT</li>{{ end }}
+        {{ end }}
+      </ul>
+
+      <div class="summary">{{ plainify .Summary | safeHTML }}</div>
+    </div>
+  </a>
+</article>

--- a/layouts/_default/li_sm.html
+++ b/layouts/_default/li_sm.html
@@ -1,0 +1,19 @@
+<article class="lism">
+  <a href="{{ .Permalink }}">
+    <div class="thumb thumb-{{ .File.UniqueID }}"></div>
+
+    <div class="inner">
+      <div class="title">{{ .Title }}</div>
+
+      <ul class="facts sm">
+        <li><i class="far fa-calendar-plus" aria-hidden="true"></i><time datetime="{{ .Date.Format "2007-01-02T15:04:05JST" }}">{{ .Date.Format ( .Site.Params.dateformat | default "Jan 2, 2006") }}</time></li>
+        {{ with .Section }}<li><i class="fas fa-bookmark" aria-hidden="true"></i>{{ . | upper }}</li>{{ end }}
+        {{ if eq (getenv "HUGO_ENV") "DEV" }}
+        <li>{{ .WordCount }} Words</li>
+        {{ if .IsDraft }}<li style="color: #2196f3;">DRAFT</li>{{ end }}
+        {{ end }}
+      </ul>
+
+    </div>
+  </a>
+</article>

--- a/layouts/_default/li_sm.html
+++ b/layouts/_default/li_sm.html
@@ -7,6 +7,7 @@
 
       <ul class="facts sm">
         <li><i class="far fa-calendar-plus" aria-hidden="true"></i><time datetime="{{ .Date.Format "2007-01-02T15:04:05JST" }}">{{ .Date.Format ( .Site.Params.dateformat | default "Jan 2, 2006") }}</time></li>
+        <li><i class="far fa-calendar-alt" aria-hidden="true"></i>{{.Params.sermon_date}}</li>
         {{ with .Section }}<li><i class="fas fa-bookmark" aria-hidden="true"></i>{{ . | upper }}</li>{{ end }}
         {{ if eq (getenv "HUGO_ENV") "DEV" }}
         <li>{{ .WordCount }} Words</li>

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -6,7 +6,7 @@
     <h1 class="title">{{ .Title }}</h1>
 
     <ul class="facts">
-      <li><i class="fa fa-calendar" aria-hidden="true"></i><time datetime="{{ .Lastmod.Format "2006-01-02T15:04:05JST" }}">{{ .Lastmod.Format ( .Site.Params.dateformat | default "Jan 2, 2006") }}</time></li>
+      <li><i class="far fa-calendar-plus" aria-hidden="true"></i><time datetime="{{ .Lastmod.Format "2006-01-02T15:04:05JST" }}">{{ .Lastmod.Format ( .Site.Params.dateformat | default "Jan 2, 2006") }}</time></li>
       {{ with .Section }}<li><i class="fa fa-bookmark" aria-hidden="true"></i><a href="{{ $.Site.BaseURL }}{{ . | urlize }}/">{{ . | upper }}</a></li>{{ end }}
       {{ if eq (getenv "HUGO_ENV") "DEV" }}
       <li>{{ .WordCount }} Words</li>

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -7,6 +7,7 @@
 
     <ul class="facts">
       <li><i class="far fa-calendar-plus" aria-hidden="true"></i><time datetime="{{ .Lastmod.Format "2006-01-02T15:04:05JST" }}">{{ .Lastmod.Format ( .Site.Params.dateformat | default "Jan 2, 2006") }}</time></li>
+      <li><i class="far fa-calendar-alt" aria-hidden="true"></i>{{.Params.sermon_date}}</li>
       {{ with .Section }}<li><i class="fa fa-bookmark" aria-hidden="true"></i><a href="{{ $.Site.BaseURL }}{{ . | urlize }}/">{{ . | upper }}</a></li>{{ end }}
       {{ if eq (getenv "HUGO_ENV") "DEV" }}
       <li>{{ .WordCount }} Words</li>


### PR DESCRIPTION
Currently it just lists the date as a string and doesn't format it at all.  That may be enough.